### PR TITLE
(attempt to) add Postmark click tracking

### DIFF
--- a/chrome/lists.js
+++ b/chrome/lists.js
@@ -150,6 +150,11 @@ function getClickTrackerList(){
 			"name": "GM", 
 			"domains": ["ec2-52-26-194-35.us-west-2.compute.amazonaws.com/x"],
 			"patterns": ["*://*.ec2-52-26-194-35.us-west-2.compute.amazonaws.com/x/*"]
+		},
+		{
+			"name": "PM", 
+			"domains": ["click.pstmrk.it"],
+			"patterns": ["*://*.pstmrk.it/*/*"]
 		}
 	];
 	return clickTrackers;


### PR DESCRIPTION
I'm not that familiar with the trocker codebase,
and don't have lots of examples from Postmark, but I saw a couple of links that look like this:

* https://click.pstmrk.it/2m/some.website.com%2Freceipt%2F18214770-83948221%2F6831526A-chre7e04233afa4-47c230da48/y0tPIA8/7cQ/OSfrX-hTZo/aW50cm9fcmVjZWlwdB
* https://click.pstmrk.it/2sm/www.website.com%2Fsubscription%2Fmanage%3Fuser%3D93849211%26subscription%3D462AC50%26hash%3Da2fa5866357ef4db77278726ce006ff4f32ce213ba5efdc14fb8ac6127e06fe4/zEtPIA8/7cQ/Rzw1Nm5KhQ/aW50cm9fcmVjZWlwdA

Hope the rule makes sense to bypass the click tracking? (I'm also not sure how to test it, I'm using the Firefox extension)