### PR TITLE
Add Github Action to Deploy to Web Stores

### DIFF
--- a/.github/workflows/deploy_to_stores.yml
+++ b/.github/workflows/deploy_to_stores.yml
@@ -1,0 +1,16 @@
+on: workflow_dispatch
+
+name: Submit to Web Stores
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create zip
+        run: cd chrome; zip -r ../extension.zip .; cd -
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v1
+        with:
+          artifact: ./extension.zip
+          keys: ${{ secrets.SUBMIT_KEYS }}


### PR DESCRIPTION
Heyo @trockerapp, nice extension! Wanted to support the open source browser extension ecosystem so we created a [Github action](https://github.com/marketplace/actions/browser-plugin-publisher) to make it easier to publish extensions to the various web stores.

Thought you might find it useful so I added a Github workflow that will zip the extension, and allow publishing to whichever web store you'd like, all within the Github UI.

The only thing you would need to create is a `SUBMIT_KEYS` GitHub repository secret.

This secret is a JSON, with the schema defined [here](https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json).

Here's a sample key:

```
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json",
  "chrome": {
    "clientId": "123",
    "clientSecret": "456",
    "refreshToken": "789",
    "extId": "abcd"
  }
}
```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me.

Otherwise, if this doesn't seem necessary, feel free to close the PR!